### PR TITLE
Use swig to make python wrapper

### DIFF
--- a/CMake/python.cmake
+++ b/CMake/python.cmake
@@ -1,13 +1,14 @@
 # Use latest UseSWIG module
 cmake_minimum_required(VERSION 3.14)
 
+set(PYTHON_PROJECT ${CMAKE_SOURCE_DIR}/pytensor)
+set(SWIG_SRC ${CMAKE_SOURCE_DIR}/swig/tensor.i)
 
-# Will need swig
+# Find SWIG
 set(CMAKE_SWIG_FLAGS)
+list(APPEND CMAKE_SWIG_FLAGS "-DSWIGWORDSIZE64")
 find_package(SWIG REQUIRED)
 include(UseSWIG)
-
-list(APPEND CMAKE_SWIG_FLAGS "-DSWIGWORDSIZE64")
 
 # Find Python
 find_package(Python REQUIRED COMPONENTS Interpreter Development)
@@ -16,7 +17,6 @@ if (Python_VERSION VERSION_GREATER_EQUAL 3)
     list(APPEND CMAKE_SWIG_FLAGS "-py3;-DPY3")
 endif ()
 
-set(SWIG_SRC ${CMAKE_SOURCE_DIR}/swig/tensor.i)
 
 # Swig wrap all libraries
 set_property(SOURCE ${SWIG_SRC} PROPERTY CPLUSPLUS ON)
@@ -28,7 +28,11 @@ swig_add_library(pytensor
 set_property(TARGET pytensor PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON)
 target_include_directories(pytensor
         PRIVATE
-        ${CMAKE_SOURCE_DIR}/include
+        ${CMAKE_SOURCE_DIR}/include_swig
         ${Python_INCLUDE_DIRS}
         )
 target_link_libraries(pytensor PRIVATE tensor ${PYTHON_LIBRARIES})
+
+file(COPY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/_pytensor.so DESTINATION ${PYTHON_PROJECT})
+file(COPY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pytensor.py DESTINATION ${PYTHON_PROJECT})
+

--- a/CMake/python.cmake
+++ b/CMake/python.cmake
@@ -1,0 +1,34 @@
+# Use latest UseSWIG module
+cmake_minimum_required(VERSION 3.14)
+
+
+# Will need swig
+set(CMAKE_SWIG_FLAGS)
+find_package(SWIG REQUIRED)
+include(UseSWIG)
+
+list(APPEND CMAKE_SWIG_FLAGS "-DSWIGWORDSIZE64")
+
+# Find Python
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
+
+if (Python_VERSION VERSION_GREATER_EQUAL 3)
+    list(APPEND CMAKE_SWIG_FLAGS "-py3;-DPY3")
+endif ()
+
+set(SWIG_SRC ${CMAKE_SOURCE_DIR}/swig/tensor.i)
+
+# Swig wrap all libraries
+set_property(SOURCE ${SWIG_SRC} PROPERTY CPLUSPLUS ON)
+set_property(SOURCE ${SWIG_SRC} PROPERTY SWIG_MODULE_NAME pytensor)
+swig_add_library(pytensor
+        LANGUAGE python
+        OUTPUT_DIR ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+        SOURCES ${SWIG_SRC})
+set_property(TARGET pytensor PROPERTY SWIG_USE_TARGET_INCLUDE_DIRECTORIES ON)
+target_include_directories(pytensor
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+        ${Python_INCLUDE_DIRS}
+        )
+target_link_libraries(pytensor PRIVATE tensor ${PYTHON_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,9 @@ endif (NOT CMAKE_BUILD_TYPE)
 
 option(TENSOR_USE_BLAS "" OFF)
 option(TENSOR_ENABLE_COVERAGE "" OFF)
-option(TENSOR_BUILD_EXAMPLES "" ON)
-option(TENSOR_BUILD_TESTS "" ON)
-option(TENSOR_BUILD_SHARED_LIBS "" ON)
+option(TENSOR_BUILD_EXAMPLES "" OFF)
+option(TENSOR_BUILD_TESTS "" OFF)
+option(TENSOR_BUILD_SHARED_LIBS "" OFF)
 
 message(STATUS "USE_BLAS: ${TENSOR_USE_BLAS}")
 message(STATUS "ENABLE_COVERAGE: ${TENSOR_ENABLE_COVERAGE}")
@@ -36,15 +36,16 @@ if (TENSOR_BUILD_SHARED_LIBS)
     set(BUILD_SHARED_LIBS ON)
 endif()
 
-set(COMPILE_OPTIONS -fno-exceptions -fno-rtti)
+#set(COMPILE_OPTIONS -fno-exceptions -fno-rtti)
+
 
 add_library(tensor
-        src/tensor/ts.hpp
+#        src/tensor/ts.hpp
         src/tensor/tensor.hpp
         src/tensor/tensor.cpp
-        src/tensor/ops_dot.cpp
-        src/tensor/ops_common.hpp
-        src/tensor/ops_common.cpp
+#        src/tensor/ops_dot.cpp
+#        src/tensor/ops_common.hpp
+#        src/tensor/ops_common.cpp
         )
 add_library(tensor::tensor ALIAS tensor)
 set_target_properties(tensor PROPERTIES LINKER_LANGUAGE CXX)
@@ -63,22 +64,22 @@ if (TENSOR_USE_BLAS)
 endif ()
 
 
-add_library(nn
-        src/tensor/nn/feed_forward.cpp
-        src/tensor/nn/cross_entropy_loss.cpp
-        src/tensor/nn/softmax.hpp
-        src/tensor/nn/planar_dataset.cpp
-        src/tensor/nn/dataset_iterator.cpp
-        )
-add_library(tensor::nn ALIAS nn)
-target_link_libraries(nn tensor)
-set_target_properties(nn PROPERTIES LINKER_LANGUAGE CXX)
-target_compile_options(nn PRIVATE ${COMPILE_OPTIONS})
-target_include_directories(nn
-        PUBLIC
-        $<INSTALL_INTERFACE:include>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-        )
+#add_library(nn
+#        src/tensor/nn/feed_forward.cpp
+#        src/tensor/nn/cross_entropy_loss.cpp
+#        src/tensor/nn/softmax.hpp
+#        src/tensor/nn/planar_dataset.cpp
+#        src/tensor/nn/dataset_iterator.cpp
+#        )
+#add_library(tensor::nn ALIAS nn)
+#target_link_libraries(nn tensor)
+#set_target_properties(nn PROPERTIES LINKER_LANGUAGE CXX)
+#target_compile_options(nn PRIVATE ${COMPILE_OPTIONS})
+#target_include_directories(nn
+#        PUBLIC
+#        $<INSTALL_INTERFACE:include>
+#        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+#        )
 
 # Enable tests only if project is not imported via add_subdirectory()
 if (TENSOR_BUILD_TESTS AND CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -113,3 +114,5 @@ endif ()
 if (TENSOR_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif ()
+
+include(CMake/python.cmake)

--- a/include_swig/tensor/tensor.hpp
+++ b/include_swig/tensor/tensor.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "tensor/tensor.hpp"

--- a/include_swig/tensor/tensor.hpp
+++ b/include_swig/tensor/tensor.hpp
@@ -1,3 +1,366 @@
 #pragma once
 
-#include "tensor/tensor.hpp"
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <vector>
+
+
+namespace ts {
+
+/**
+ *
+ * @tparam Element is the type of array element
+ * @tparam Dim is the number of dimensions
+ */
+
+template <typename Element, int Dim> class Tensor {
+
+  public:
+    using size_type = int;
+    using vector_t = std::vector<Element>;
+    using data_t = std::shared_ptr<vector_t>;
+    using iterator = typename vector_t::iterator;
+
+    auto data() const -> data_t { return _data; };
+    auto shape() const -> std::array<size_type, Dim> { return _dimensions; }
+    auto data_size() const -> size_type { return _data_size; }
+
+    auto begin() -> iterator { return _begin; }
+    auto end() -> iterator { return _end; }
+    auto begin() const -> iterator { return _begin; }
+    auto end() const -> iterator { return _end; }
+
+    Tensor();
+
+    Tensor(std::array<size_type, Dim> shape);
+
+    template <typename... Sizes> Tensor(size_type first, Sizes... rest);
+
+    Tensor(Tensor const &tensor);
+
+//    template <typename... Indices>
+//    auto operator()(size_type first, Indices... rest) -> decltype(auto);
+//
+//    template <typename... Indices>
+//    auto operator()(size_type first, Indices... rest) const -> decltype(auto);
+
+//    auto operator[](size_type i) -> decltype(auto);
+
+    auto operator==(Tensor<Element, Dim> const &other) const -> bool;
+
+    auto operator!=(Tensor<Element, Dim> const &other) -> bool;
+
+    Tensor& operator=(Tensor const &tensor);
+
+//    auto operator<(Element const &value) -> Tensor<bool, Dim>;
+//
+//    auto operator<=(Element const &value) -> Tensor<bool, Dim>;
+//
+//    auto operator>(Element const &value) -> Tensor<bool, Dim>;
+//
+//    auto operator>=(Element const &value) -> Tensor<bool, Dim>;
+//
+//    auto operator==(Element const &value) -> Tensor<bool, Dim>;
+
+    Tensor& operator+=(Tensor const &tensor);
+
+    Tensor& operator-();
+
+    Tensor randn(std::vector<int> shape);
+
+  private:
+    size_type _data_size;
+    std::array<size_type, Dim> _dimensions;
+    std::shared_ptr<std::vector<Element>> _data;
+    iterator _begin;
+    iterator _end;
+
+    template <typename... Sizes> auto set_sizes(int pos, size_type first, Sizes... rest) -> void;
+
+    template <typename... Indices>
+    auto get_index(int pos, size_type prev_index, size_type first, Indices... rest) const
+    -> size_type;
+};
+
+template <typename Element, int Dim> Tensor<Element, Dim>::Tensor()
+{
+    _data = nullptr;
+    _data_size = 0;
+}
+
+template <typename Element, int Dim>
+template <typename... Sizes>
+Tensor<Element, Dim>::Tensor(Tensor::size_type first, Sizes... rest)
+{
+    set_sizes(0, first, rest...);
+    _data = std::make_shared<vector_t>(_data_size);
+    _begin = _data->begin();
+    _end = _data->end();
+}
+
+template <typename Element, int Dim> Tensor<Element, Dim>::Tensor(Tensor const &tensor)
+{
+    _data_size = tensor.data_size();
+    _dimensions = tensor.shape();
+    _data = std::make_shared<vector_t>(*tensor.data());
+    _begin = _data->begin();
+    _end = _data->end();
+}
+
+//template <typename Element, int Dim>
+//Tensor<Element, Dim>::Tensor(Tensor<Element, Dim + 1> const &tensor, Tensor::size_type index)
+//{
+//    std::copy(tensor.shape().begin() + 1, tensor.shape().end(), _dimensions.begin());
+//    _data_size = tensor.data_size() / tensor.shape()[0];
+//    _data = tensor.data();
+//    _begin = _data->begin() + index * _data_size;
+//    _end = _begin + _data_size; // TODO: I added +1 and nothing tests didn't break :/
+//}
+
+template <typename Element, int Dim>
+Tensor<Element, Dim>::Tensor(std::array<size_type, Dim> shape)
+{
+    std::copy(shape.begin(), shape.end(), _dimensions.begin());
+    _data_size = std::reduce(shape.begin(), shape.end(), 1, std::multiplies<>());
+    _data = std::make_shared<vector_t>(_data_size);
+    _begin = _data->begin();
+    _end = _data->end();
+}
+
+//template <typename Element, int Dim>
+//template <typename... Indices>
+//auto Tensor<Element, Dim>::operator()(Tensor::size_type first, Indices... rest) -> decltype(auto)
+//{
+//    if constexpr (sizeof...(Indices) == Dim - 1) {
+//        return _begin[get_index(0, 0, first, rest...)];
+//    } else if constexpr (Dim >= 2 && sizeof...(Indices) == 0) {
+//        return Tensor<Element, Dim - 1>(*this, first);
+//    } else if constexpr (Dim >= 2 && sizeof...(Indices) < Dim - 1) {
+//        return Tensor<Element, Dim - 1>(*this, first)(rest...);
+//    } else {
+//        assert(false);
+//    }
+//}
+//
+//template <typename Element, int Dim>
+//template <typename... Indices>
+//auto Tensor<Element, Dim>::operator()(Tensor::size_type first, Indices... rest) const
+//    -> decltype(auto)
+//{
+//    if constexpr (sizeof...(Indices) == Dim - 1) {
+//        return _begin[get_index(0, 0, first, rest...)];
+//    } else if constexpr (Dim >= 2 && sizeof...(Indices) == 0) {
+//        return Tensor<Element, Dim - 1>(*this, first);
+//    } else if constexpr (Dim >= 2 && sizeof...(Indices) < Dim - 1) {
+//        return Tensor<Element, Dim - 1>(*this, first)(rest...);
+//    } else {
+//        assert(false);
+//    }
+//}
+
+template <typename Element, int Dim>
+auto Tensor<Element, Dim>::operator==(const Tensor<Element, Dim> &other) const -> bool
+{
+    if (_data_size != other.data_size()) {
+        return false;
+    }
+    return std::equal(other.begin(), other.end(), _begin);
+}
+
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator[](Tensor::size_type i) -> decltype(auto)
+//{
+//    if constexpr (Dim == 1) {
+//        return _begin[i];
+//    } else {
+//        return Tensor<Element, Dim - 1>(*this, i);
+//    }
+//}
+
+template <typename Element, int Dim>
+auto Tensor<Element, Dim>::operator!=(const Tensor<Element, Dim> &other) -> bool
+{
+    return !(*this == other);
+}
+
+template <typename Element, int Dim>
+Tensor<Element, Dim>& Tensor<Element, Dim>::operator=(Tensor const &tensor)
+{
+    if (this == &tensor)
+        return *this;
+
+    _data = tensor.data();
+    _data_size = tensor.data_size();
+    _dimensions = tensor.shape();
+    _begin = tensor.begin();
+    _end = tensor.end();
+
+    return *this;
+}
+
+template <typename Element, int Dim>
+auto Tensor<Element, Dim>::randn(std::vector<int> shape) -> Tensor
+{
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    std::normal_distribution<Element> dist{0.0};
+
+    std::array<int, Dim> array_shape;
+    // TODO: this is weird solution :P
+    std::copy(shape.begin(), shape.end(), array_shape.begin());
+    Tensor<Element, Dim> tensor(array_shape);
+    std::generate(tensor.begin(), tensor.end(), [&]() { return dist(mt); });
+    return tensor;
+}
+
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator<(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e < value; });
+//}
+//
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator<=(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e <= value; });
+//}
+//
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator>(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e > value; });
+//}
+//
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator>=(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e >= value; });
+//}
+//
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator==(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e == value; });
+//}
+
+template <typename Element, int Dim>
+Tensor<Element, Dim>& Tensor<Element, Dim>::operator+=(Tensor const &tensor)
+{
+    std::transform(_begin, _end, tensor.begin(), _begin, std::plus());
+    return *this;
+}
+
+template <typename Element, int Dim>
+template <typename... Sizes>
+auto Tensor<Element, Dim>::set_sizes(int pos, Tensor::size_type first, Sizes... rest) -> void
+{
+    if (pos == 0) {
+        _data_size = 1;
+    }
+    _dimensions[pos] = first;
+    _data_size *= first;
+
+    if constexpr (sizeof...(rest) > 0) {
+        set_sizes(pos + 1, rest...);
+    }
+}
+
+template <typename Element, int Dim>
+template <typename... Indices>
+auto Tensor<Element, Dim>::get_index(int pos, Tensor::size_type prev_index, Tensor::size_type first,
+                                     Indices... rest) const -> Tensor::size_type
+{
+    size_type index = (prev_index * _dimensions[pos]) + first;
+    if constexpr (sizeof...(rest) > 0) {
+        return get_index(pos + 1, index, rest...);
+    } else {
+        return index;
+    }
+}
+
+//template <typename Element, int Dim>
+//Tensor<Element, Dim>::Tensor(std::initializer_list<Tensor<Element, Dim - 1>> list)
+//{
+//    if (list.size() == 0) {
+//        _data_size = 0;
+//        _data = nullptr;
+//        return;
+//    }
+//    _data_size = 0;
+//    _dimensions[0] = list.size();
+//    for (auto const &tensor : list) {
+//        if (_data_size == 0) {
+//            for (int i = 0; i < tensor.shape().size(); ++i) {
+//                _dimensions[i + 1] = tensor.shape()[i];
+//            }
+//        }
+//        _data_size += tensor.data_size();
+//    }
+//
+//    _data = std::make_shared<vector_t>(_data_size);
+//    auto data_end = _data->begin();
+//    for (auto const &tensor : list) {
+//        data_end = std::copy(tensor.begin(), tensor.end(), data_end);
+//    }
+//    _begin = _data->begin();
+//    _end = data_end;
+//}
+//
+//template <typename Element, int Dim>
+//Tensor<Element, Dim>::Tensor(std::vector<Tensor<Element, Dim - 1>> list)
+//{
+//    if (list.size() == 0) {
+//        _data_size = 0;
+//        _data = nullptr;
+//        return;
+//    }
+//    _data_size = 0;
+//    _dimensions[0] = list.size();
+//    for (auto const &tensor : list) {
+//        if (_data_size == 0) {
+//            for (int i = 0; i < tensor.shape().size(); ++i) {
+//                _dimensions[i + 1] = tensor.shape()[i];
+//            }
+//        }
+//        _data_size += tensor.data_size();
+//    }
+//
+//    _data = std::make_shared<vector_t>(_data_size);
+//    auto data_end = _data->begin();
+//    for (auto const &tensor : list) {
+//        data_end = std::copy(tensor.begin(), tensor.end(), data_end);
+//    }
+//    _begin = _data->begin();
+//    _end = data_end;
+//}
+
+//template <typename Element, int Dim>
+//Tensor<Element, Dim>::Tensor(std::initializer_list<Element> list)
+//{
+//    if (list.size() == 0) {
+//        _data_size = 0;
+//        _data = nullptr;
+//        return;
+//    }
+//    _data_size = list.size();
+//    _dimensions[0] = _data_size;
+//    _data = std::make_shared<vector_t>(list.begin(), list.end());
+//    _begin = _data->begin();
+//    _end = _data->end();
+//}
+
+template <typename Element, int Dim>
+Tensor<Element, Dim>& Tensor<Element, Dim>::operator-()
+{
+    std::transform(_begin, _end, _begin, [](Element const &e) { return -e;});
+    return *this;
+}
+
+} // namespace ts

--- a/pytensor/tests/test_pytensor.py
+++ b/pytensor/tests/test_pytensor.py
@@ -1,0 +1,18 @@
+import pytensor as pts
+
+
+def test_create_empty_tensor():
+    tensor = pts.TensorF2()
+    assert tensor.data_size() == 0
+
+
+def test_create_initialized_tensor():
+    tensor = pts.TensorF2([2, 2])
+
+    assert tensor.data_size() == 4
+
+
+def test_random_tensor():
+    tensor = pts.TensorF2().randn([2, 2])
+
+    assert tensor.data_size() == 4

--- a/src/tensor/tensor.hpp
+++ b/src/tensor/tensor.hpp
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <vector>
 
-#include "ops.hpp"
 #include "tensor_forward.hpp"
 
 namespace ts {
@@ -30,7 +29,7 @@ template <typename Element, int Dim> class Tensor {
 
     auto data() const -> data_t { return _data; };
     auto shape() const -> std::array<size_type, Dim> { return _dimensions; }
-    [[nodiscard]] auto data_size() const -> size_type { return _data_size; }
+    auto data_size() const -> size_type { return _data_size; }
 
     auto begin() -> iterator { return _begin; }
     auto end() -> iterator { return _end; }
@@ -41,9 +40,9 @@ template <typename Element, int Dim> class Tensor {
 
     Tensor(std::initializer_list<Element> list);
 
-    Tensor(std::initializer_list<Tensor<Element, Dim - 1>> list);
+//    Tensor(std::initializer_list<Tensor<Element, Dim - 1>> list);
 
-    Tensor(std::vector<Tensor<Element, Dim - 1>> list);
+//    Tensor(std::vector<Tensor<Element, Dim - 1>> list);
 
     Tensor(std::array<size_type, Dim> const &shape);
 
@@ -51,37 +50,37 @@ template <typename Element, int Dim> class Tensor {
 
     Tensor(Tensor const &tensor);
 
-    Tensor(Tensor<Element, Dim + 1> const &tensor, size_type index);
+//    Tensor(Tensor<Element, Dim + 1> const &tensor, size_type index);
 
-    template <typename... Indices>
-    auto operator()(size_type first, Indices... rest) -> decltype(auto);
+//    template <typename... Indices>
+//    auto operator()(size_type first, Indices... rest) -> decltype(auto);
+//
+//    template <typename... Indices>
+//    auto operator()(size_type first, Indices... rest) const -> decltype(auto);
 
-    template <typename... Indices>
-    auto operator()(size_type first, Indices... rest) const -> decltype(auto);
-
-    auto operator[](size_type i) -> decltype(auto);
+//    auto operator[](size_type i) -> decltype(auto);
 
     auto operator==(Tensor<Element, Dim> const &other) const -> bool;
 
     auto operator!=(Tensor<Element, Dim> const &other) -> bool;
 
-    auto operator=(Tensor const &tensor) -> Tensor &;
+    Tensor& operator=(Tensor const &tensor);
 
-    auto operator<(Element const &value) -> Tensor<bool, Dim>;
+//    auto operator<(Element const &value) -> Tensor<bool, Dim>;
+//
+//    auto operator<=(Element const &value) -> Tensor<bool, Dim>;
+//
+//    auto operator>(Element const &value) -> Tensor<bool, Dim>;
+//
+//    auto operator>=(Element const &value) -> Tensor<bool, Dim>;
+//
+//    auto operator==(Element const &value) -> Tensor<bool, Dim>;
 
-    auto operator<=(Element const &value) -> Tensor<bool, Dim>;
+    Tensor& operator+=(Tensor const &tensor);
 
-    auto operator>(Element const &value) -> Tensor<bool, Dim>;
+    Tensor& operator-();
 
-    auto operator>=(Element const &value) -> Tensor<bool, Dim>;
-
-    auto operator==(Element const &value) -> Tensor<bool, Dim>;
-
-    auto operator+=(Tensor const &tensor) -> Tensor &;
-
-    auto operator-() -> Tensor &;
-
-    auto static randn(std::vector<int> const &shape) -> Tensor;
+    Tensor randn(std::vector<int> const &shape);
 
   private:
     size_type _data_size;
@@ -122,15 +121,15 @@ template <typename Element, int Dim> Tensor<Element, Dim>::Tensor(Tensor const &
     _end = _data->end();
 }
 
-template <typename Element, int Dim>
-Tensor<Element, Dim>::Tensor(Tensor<Element, Dim + 1> const &tensor, Tensor::size_type index)
-{
-    std::copy(tensor.shape().begin() + 1, tensor.shape().end(), _dimensions.begin());
-    _data_size = tensor.data_size() / tensor.shape()[0];
-    _data = tensor.data();
-    _begin = _data->begin() + index * _data_size;
-    _end = _begin + _data_size; // TODO: I added +1 and nothing tests didn't break :/
-}
+//template <typename Element, int Dim>
+//Tensor<Element, Dim>::Tensor(Tensor<Element, Dim + 1> const &tensor, Tensor::size_type index)
+//{
+//    std::copy(tensor.shape().begin() + 1, tensor.shape().end(), _dimensions.begin());
+//    _data_size = tensor.data_size() / tensor.shape()[0];
+//    _data = tensor.data();
+//    _begin = _data->begin() + index * _data_size;
+//    _end = _begin + _data_size; // TODO: I added +1 and nothing tests didn't break :/
+//}
 
 template <typename Element, int Dim>
 Tensor<Element, Dim>::Tensor(const std::array<size_type, Dim> &shape)
@@ -142,36 +141,36 @@ Tensor<Element, Dim>::Tensor(const std::array<size_type, Dim> &shape)
     _end = _data->end();
 }
 
-template <typename Element, int Dim>
-template <typename... Indices>
-auto Tensor<Element, Dim>::operator()(Tensor::size_type first, Indices... rest) -> decltype(auto)
-{
-    if constexpr (sizeof...(Indices) == Dim - 1) {
-        return _begin[get_index(0, 0, first, rest...)];
-    } else if constexpr (Dim >= 2 && sizeof...(Indices) == 0) {
-        return Tensor<Element, Dim - 1>(*this, first);
-    } else if constexpr (Dim >= 2 && sizeof...(Indices) < Dim - 1) {
-        return Tensor<Element, Dim - 1>(*this, first)(rest...);
-    } else {
-        assert(false);
-    }
-}
-
-template <typename Element, int Dim>
-template <typename... Indices>
-auto Tensor<Element, Dim>::operator()(Tensor::size_type first, Indices... rest) const
-    -> decltype(auto)
-{
-    if constexpr (sizeof...(Indices) == Dim - 1) {
-        return _begin[get_index(0, 0, first, rest...)];
-    } else if constexpr (Dim >= 2 && sizeof...(Indices) == 0) {
-        return Tensor<Element, Dim - 1>(*this, first);
-    } else if constexpr (Dim >= 2 && sizeof...(Indices) < Dim - 1) {
-        return Tensor<Element, Dim - 1>(*this, first)(rest...);
-    } else {
-        assert(false);
-    }
-}
+//template <typename Element, int Dim>
+//template <typename... Indices>
+//auto Tensor<Element, Dim>::operator()(Tensor::size_type first, Indices... rest) -> decltype(auto)
+//{
+//    if constexpr (sizeof...(Indices) == Dim - 1) {
+//        return _begin[get_index(0, 0, first, rest...)];
+//    } else if constexpr (Dim >= 2 && sizeof...(Indices) == 0) {
+//        return Tensor<Element, Dim - 1>(*this, first);
+//    } else if constexpr (Dim >= 2 && sizeof...(Indices) < Dim - 1) {
+//        return Tensor<Element, Dim - 1>(*this, first)(rest...);
+//    } else {
+//        assert(false);
+//    }
+//}
+//
+//template <typename Element, int Dim>
+//template <typename... Indices>
+//auto Tensor<Element, Dim>::operator()(Tensor::size_type first, Indices... rest) const
+//    -> decltype(auto)
+//{
+//    if constexpr (sizeof...(Indices) == Dim - 1) {
+//        return _begin[get_index(0, 0, first, rest...)];
+//    } else if constexpr (Dim >= 2 && sizeof...(Indices) == 0) {
+//        return Tensor<Element, Dim - 1>(*this, first);
+//    } else if constexpr (Dim >= 2 && sizeof...(Indices) < Dim - 1) {
+//        return Tensor<Element, Dim - 1>(*this, first)(rest...);
+//    } else {
+//        assert(false);
+//    }
+//}
 
 template <typename Element, int Dim>
 auto Tensor<Element, Dim>::operator==(const Tensor<Element, Dim> &other) const -> bool
@@ -182,15 +181,15 @@ auto Tensor<Element, Dim>::operator==(const Tensor<Element, Dim> &other) const -
     return std::equal(other.begin(), other.end(), _begin);
 }
 
-template <typename Element, int Dim>
-auto Tensor<Element, Dim>::operator[](Tensor::size_type i) -> decltype(auto)
-{
-    if constexpr (Dim == 1) {
-        return _begin[i];
-    } else {
-        return Tensor<Element, Dim - 1>(*this, i);
-    }
-}
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator[](Tensor::size_type i) -> decltype(auto)
+//{
+//    if constexpr (Dim == 1) {
+//        return _begin[i];
+//    } else {
+//        return Tensor<Element, Dim - 1>(*this, i);
+//    }
+//}
 
 template <typename Element, int Dim>
 auto Tensor<Element, Dim>::operator!=(const Tensor<Element, Dim> &other) -> bool
@@ -199,7 +198,7 @@ auto Tensor<Element, Dim>::operator!=(const Tensor<Element, Dim> &other) -> bool
 }
 
 template <typename Element, int Dim>
-auto Tensor<Element, Dim>::operator=(Tensor const &tensor) -> Tensor &
+Tensor<Element, Dim>& Tensor<Element, Dim>::operator=(Tensor const &tensor)
 {
     if (this == &tensor)
         return *this;
@@ -228,38 +227,38 @@ auto Tensor<Element, Dim>::randn(const std::vector<int> &shape) -> Tensor
     return tensor;
 }
 
-template <typename Element, int Dim>
-auto Tensor<Element, Dim>::operator<(const Element &value) -> Tensor<bool, Dim>
-{
-    return ts::mask<Element, Dim>(*this, [&](Element e) { return e < value; });
-}
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator<(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e < value; });
+//}
+//
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator<=(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e <= value; });
+//}
+//
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator>(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e > value; });
+//}
+//
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator>=(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e >= value; });
+//}
+//
+//template <typename Element, int Dim>
+//auto Tensor<Element, Dim>::operator==(const Element &value) -> Tensor<bool, Dim>
+//{
+//    return ts::mask<Element, Dim>(*this, [&](Element e) { return e == value; });
+//}
 
 template <typename Element, int Dim>
-auto Tensor<Element, Dim>::operator<=(const Element &value) -> Tensor<bool, Dim>
-{
-    return ts::mask<Element, Dim>(*this, [&](Element e) { return e <= value; });
-}
-
-template <typename Element, int Dim>
-auto Tensor<Element, Dim>::operator>(const Element &value) -> Tensor<bool, Dim>
-{
-    return ts::mask<Element, Dim>(*this, [&](Element e) { return e > value; });
-}
-
-template <typename Element, int Dim>
-auto Tensor<Element, Dim>::operator>=(const Element &value) -> Tensor<bool, Dim>
-{
-    return ts::mask<Element, Dim>(*this, [&](Element e) { return e >= value; });
-}
-
-template <typename Element, int Dim>
-auto Tensor<Element, Dim>::operator==(const Element &value) -> Tensor<bool, Dim>
-{
-    return ts::mask<Element, Dim>(*this, [&](Element e) { return e == value; });
-}
-
-template <typename Element, int Dim>
-auto Tensor<Element, Dim>::operator+=(Tensor const &tensor) -> Tensor &
+Tensor<Element, Dim>& Tensor<Element, Dim>::operator+=(Tensor const &tensor)
 {
     std::transform(_begin, _end, tensor.begin(), _begin, std::plus());
     return *this;
@@ -293,61 +292,61 @@ auto Tensor<Element, Dim>::get_index(int pos, Tensor::size_type prev_index, Tens
     }
 }
 
-template <typename Element, int Dim>
-Tensor<Element, Dim>::Tensor(std::initializer_list<Tensor<Element, Dim - 1>> list)
-{
-    if (list.size() == 0) {
-        _data_size = 0;
-        _data = nullptr;
-        return;
-    }
-    _data_size = 0;
-    _dimensions[0] = list.size();
-    for (auto const &tensor : list) {
-        if (_data_size == 0) {
-            for (int i = 0; i < tensor.shape().size(); ++i) {
-                _dimensions[i + 1] = tensor.shape()[i];
-            }
-        }
-        _data_size += tensor.data_size();
-    }
-
-    _data = std::make_shared<vector_t>(_data_size);
-    auto data_end = _data->begin();
-    for (auto const &tensor : list) {
-        data_end = std::copy(tensor.begin(), tensor.end(), data_end);
-    }
-    _begin = _data->begin();
-    _end = data_end;
-}
-
-template <typename Element, int Dim>
-Tensor<Element, Dim>::Tensor(std::vector<Tensor<Element, Dim - 1>> list)
-{
-    if (list.size() == 0) {
-        _data_size = 0;
-        _data = nullptr;
-        return;
-    }
-    _data_size = 0;
-    _dimensions[0] = list.size();
-    for (auto const &tensor : list) {
-        if (_data_size == 0) {
-            for (int i = 0; i < tensor.shape().size(); ++i) {
-                _dimensions[i + 1] = tensor.shape()[i];
-            }
-        }
-        _data_size += tensor.data_size();
-    }
-
-    _data = std::make_shared<vector_t>(_data_size);
-    auto data_end = _data->begin();
-    for (auto const &tensor : list) {
-        data_end = std::copy(tensor.begin(), tensor.end(), data_end);
-    }
-    _begin = _data->begin();
-    _end = data_end;
-}
+//template <typename Element, int Dim>
+//Tensor<Element, Dim>::Tensor(std::initializer_list<Tensor<Element, Dim - 1>> list)
+//{
+//    if (list.size() == 0) {
+//        _data_size = 0;
+//        _data = nullptr;
+//        return;
+//    }
+//    _data_size = 0;
+//    _dimensions[0] = list.size();
+//    for (auto const &tensor : list) {
+//        if (_data_size == 0) {
+//            for (int i = 0; i < tensor.shape().size(); ++i) {
+//                _dimensions[i + 1] = tensor.shape()[i];
+//            }
+//        }
+//        _data_size += tensor.data_size();
+//    }
+//
+//    _data = std::make_shared<vector_t>(_data_size);
+//    auto data_end = _data->begin();
+//    for (auto const &tensor : list) {
+//        data_end = std::copy(tensor.begin(), tensor.end(), data_end);
+//    }
+//    _begin = _data->begin();
+//    _end = data_end;
+//}
+//
+//template <typename Element, int Dim>
+//Tensor<Element, Dim>::Tensor(std::vector<Tensor<Element, Dim - 1>> list)
+//{
+//    if (list.size() == 0) {
+//        _data_size = 0;
+//        _data = nullptr;
+//        return;
+//    }
+//    _data_size = 0;
+//    _dimensions[0] = list.size();
+//    for (auto const &tensor : list) {
+//        if (_data_size == 0) {
+//            for (int i = 0; i < tensor.shape().size(); ++i) {
+//                _dimensions[i + 1] = tensor.shape()[i];
+//            }
+//        }
+//        _data_size += tensor.data_size();
+//    }
+//
+//    _data = std::make_shared<vector_t>(_data_size);
+//    auto data_end = _data->begin();
+//    for (auto const &tensor : list) {
+//        data_end = std::copy(tensor.begin(), tensor.end(), data_end);
+//    }
+//    _begin = _data->begin();
+//    _end = data_end;
+//}
 
 template <typename Element, int Dim>
 Tensor<Element, Dim>::Tensor(std::initializer_list<Element> list)
@@ -365,7 +364,7 @@ Tensor<Element, Dim>::Tensor(std::initializer_list<Element> list)
 }
 
 template <typename Element, int Dim>
-auto Tensor<Element, Dim>::operator-() -> Tensor &
+Tensor<Element, Dim>& Tensor<Element, Dim>::operator-()
 {
     std::transform(_begin, _end, _begin, [](Element const &e) { return -e;});
     return *this;

--- a/swig/tensor.i
+++ b/swig/tensor.i
@@ -1,0 +1,9 @@
+%module tensor
+%{
+#include <tensor/tensor.hpp>
+%}
+
+/* Parse the header file to generate wrappers */
+%include <std_vector.i>
+%include "../src/tensor/tensor.hpp"
+%template(TensorF2) ts::Tensor<float, 2>;

--- a/swig/tensor.i
+++ b/swig/tensor.i
@@ -5,5 +5,10 @@
 
 /* Parse the header file to generate wrappers */
 %include <std_vector.i>
-%include "../src/tensor/tensor.hpp"
+%include <std_array.i>
+
+%template(VectorInt) std::vector<int>;
+%template(ArrayI2) std::array<int, 2>;
+
+%include "../include_swig/tensor/tensor.hpp"
 %template(TensorF2) ts::Tensor<float, 2>;


### PR DESCRIPTION
I tried to use swig for generating glue code for the python wrapper but I did fail miserably. I thought that it would be easier to make interface files that could generate wrappers for both java and python but it is not as I need my python wrapper to work interchangeably with NumPy arrays. For now, I think that pybind11 is a better tool for a job.

Fixes #16 